### PR TITLE
flushing a classloader in aem 6.5 via curl

### DIFF
--- a/vars/aem.groovy
+++ b/vars/aem.groovy
@@ -225,7 +225,7 @@ def flushJsp(configObject) {
   withCredentials([usernameColonPassword(credentialsId: configObject.global.aem_admin_id, variable: 'admin')]){
     instances.each {instance ->
       log.printMagenta("[INFO] Sending cURL to slingjsp on ${instance}")
-      sh(script: "curl -u ${admin} -I -X POST http://${instance}/system/console/slingjsp")
+      sh(script: "curl -u ${admin} -I -X POST http://${instance}/system/console/fsclassloader -d 'clear=true'")
       // sh(script: "curl -u ${admin} -X POST http://${instance}/system/console/scriptcache")
     }
   }


### PR DESCRIPTION
change method which can flush a classloader in aem 6.5 (aka JSP in aem 6.3)

The solution was found here:
https://experienceleaguecommunities.adobe.com/t5/adobe-experience-manager/recompile-jsps-not-available-in-aem-6-5/qaq-p/310264